### PR TITLE
Change to a postprocessing site hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/_site
 /tmp
 /spec/examples.txt
+/spec/fixtures/output/
 /Gemfile.lock
 *.gem

--- a/lib/jekyll-relative-links.rb
+++ b/lib/jekyll-relative-links.rb
@@ -1,6 +1,10 @@
 require "jekyll"
-require "jekyll-relative-links/generator"
+require "jekyll-relative-links/hook"
 require "jekyll-relative-links/context"
 
 module JekyllRelativeLinks
+end
+
+Jekyll::Hooks.register :site, :post_render do |site|
+  JekyllRelativeLinks::Hook.new(site).convert
 end

--- a/lib/jekyll-relative-links/hook.rb
+++ b/lib/jekyll-relative-links/hook.rb
@@ -23,7 +23,6 @@ module JekyllRelativeLinks
         url_base = File.dirname(page.path)
 
         page.content.gsub!(LINK_REGEX) do |anchor|
-          # puts original
           original_href = Regexp.last_match(1)
           original_href.sub!(%r!\A/!, "")
           url = url_for_path(path_from_root(original_href, url_base))

--- a/lib/jekyll-relative-links/hook.rb
+++ b/lib/jekyll-relative-links/hook.rb
@@ -1,24 +1,20 @@
 module JekyllRelativeLinks
-  class Generator < Jekyll::Generator
+  class Hook
     attr_accessor :site
 
     # Use Jekyll's native relative_url filter
     include Jekyll::Filters::URLFilters
 
-    INLINE_LINK_REGEX = %r!\[([^\]]+)\]\(([^\)]+)\)!
-    REFERENCE_LINK_REGEX = %r!^\[([^\]]+)\]: (.*)$!
-    LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!
+    HREF_REGEX = %r!href=\"(.*?)\"!
+    LINK_REGEX = %r!<a[^>]+#{HREF_REGEX}[^>]*>!
     CONVERTER_CLASS = Jekyll::Converters::Markdown
-
-    safe true
-    priority :lowest
 
     def initialize(site)
       @site    = site
       @context = context
     end
 
-    def generate(site)
+    def convert
       @site    = site
       @context = context
 
@@ -26,17 +22,16 @@ module JekyllRelativeLinks
         next unless markdown_extension?(page.extname)
         url_base = File.dirname(page.path)
 
-        page.content.gsub!(LINK_REGEX) do |original|
-          link_type     = Regexp.last_match(2) ? :inline : :reference
-          link_text     = Regexp.last_match(link_type == :inline ? 2 : 4)
-          relative_path = Regexp.last_match(link_type == :inline ? 3 : 5)
-          relative_path.sub!(%r!\A/!, "")
-          url = url_for_path(path_from_root(relative_path, url_base))
+        page.content.gsub!(LINK_REGEX) do |anchor|
+          # puts original
+          original_href = Regexp.last_match(1)
+          original_href.sub!(%r!\A/!, "")
+          url = url_for_path(path_from_root(original_href, url_base))
 
           if url
-            replacement_text(link_type, link_text, url)
+            anchor.sub!(HREF_REGEX, %(href="#{url}"))
           else
-            original
+            anchor
           end
         end
       end

--- a/spec/jekyll-relative-links/hook_spec.rb
+++ b/spec/jekyll-relative-links/hook_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe JekyllRelativeLinks::Generator do
+RSpec.describe JekyllRelativeLinks::Hook do
   let(:site) { fixture_site("site") }
   let(:page) { page_by_path(site, "page.md") }
   let(:html_page) { page_by_path(site, "html-page.html") }
@@ -9,7 +9,7 @@ RSpec.describe JekyllRelativeLinks::Generator do
 
   before(:each) do
     site.reset
-    site.read
+    site.process
   end
 
   it "saves the site" do
@@ -31,71 +31,63 @@ RSpec.describe JekyllRelativeLinks::Generator do
   end
 
   context "generating" do
-    before { subject.generate(site) }
-
     it "converts relative links" do
-      expect(page.content).to include("[Another Page](/another-page.html)")
+      expect(page.content).to include(%(href="/another-page.html"))
     end
 
     it "converts relative links with permalinks" do
-      expect(page.content).to include("[Page with permalink](/page-with-permalink/)")
+      expect(page.content).to include(%(href="/page-with-permalink/"))
     end
 
     it "converts relative links with leading slashes" do
-      expect(page.content).to include("[Page with leading slash](/another-page.html)")
+      expect(page.content).to include(%(href="/another-page.html"))
     end
 
     it "converts pages in sub-directories" do
-      expect(page.content).to include("[Subdir Page](/subdir/page.html)")
+      expect(page.content).to include(%(href="/subdir/page.html"))
     end
 
     it "handles links within subdirectories" do
-      expected = "[Another subdir page](/subdir/another-subdir-page.html)"
+      expected = %(href="/subdir/another-subdir-page.html")
       expect(subdir_page.content).to include(expected)
     end
 
     it "handles relative links within subdirectories" do
-      expected = "[Relative subdir page](/subdir/another-subdir-page.html)"
+      expected = %(href="/subdir/another-subdir-page.html")
       expect(subdir_page.content).to include(expected)
     end
 
     it "handles directory traversal" do
-      expect(subdir_page.content).to include("[Dir traversal](/page.html)")
+      expect(subdir_page.content).to include(%(href="/page.html"))
     end
 
     it "doesn't mangle HTML pages" do
-      expect(page.content).to include("[HTML Page](html-page.html)")
+      expect(page.content).to include(%(href="html-page.html"))
     end
 
     it "doesn't mangle invalid pages" do
-      expect(page.content).to include("[Ghost page](ghost-page.md)")
-    end
-
-    context "reference links" do
-      it "handles reference links" do
-        expect(page.content).to include("[reference]: /another-page.html")
-      end
+      expect(page.content).to include(%(href="ghost-page.md"))
     end
 
     context "with a baseurl" do
       let(:site) { fixture_site("site", :baseurl => "/foo") }
 
       it "converts relative links" do
-        expect(page.content).to include("[Another Page](/foo/another-page.html)")
+        expect(page.content).to include(%(href="/foo/another-page.html"))
       end
 
       it "handles links within subdirectories" do
-        expected = "[Another subdir page](/foo/subdir/another-subdir-page.html)"
+        expected = %(href="/foo/subdir/another-subdir-page.html")
         expect(subdir_page.content).to include(expected)
       end
 
       it "handles relative links within subdirectories" do
-        expected = "[Relative subdir page](/foo/subdir/another-subdir-page.html)"
+        expected = %(href="/foo/subdir/another-subdir-page.html")
         expect(subdir_page.content).to include(expected)
       end
 
       it "handles directory traversal" do
-        expect(subdir_page.content).to include("[Dir traversal](/foo/page.html)")
+        expect(subdir_page.content).to include(%(href="/foo/page.html"))
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,9 @@ def fixture_path(fixture)
 end
 
 def fixture_site(fixture, override = {})
-  default_config = { "source" => fixture_path(fixture) }
+  default_config = { "source"      => fixture_path(fixture),
+                     "destination" => fixture_path("output") }
+
   config = Jekyll::Utils.deep_merge_hashes(default_config, override)
   config = Jekyll.configuration(config)
   Jekyll::Site.new(config)


### PR DESCRIPTION
Validated by @parkr, this PR changes the plugin to hook into `:site, :post_render`. This is safer than parsing the raw Markdown via regex, because Markdown links can take all sorts of zany forms (especially if you try to [conform to Commonmark](http://spec.commonmark.org/0.27/#links)).

Much of the original plugin remains intact. You'll also notice that the only thing that changed in the test was to expect `.html` suffixes, not the raw Markdown text.

You might be wondering why I'm (again) using regexes here instead of something like Nokogiri. First, Nokogiri requires a native extension, so compilation might be a problem for Windows. But also, Nokogiri mangles the resulting HTML in its own unique way. Relying on a simple regex allows the rest of the HTML to remain unchanged.

cc @benbalter for review