### PR TITLE
HTML Pipeline filter to make all relative urls absolute

### DIFF
--- a/jekyll-relative-links.gemspec
+++ b/jekyll-relative-links.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
 
   s.add_dependency "jekyll", "~> 3.3"
+  s.add_dependency "html-pipeline"
+  s.add_dependency "addressable"
   s.add_development_dependency "rubocop", "~> 0.43"
   s.add_development_dependency "rspec", "~> 3.5"
 end

--- a/lib/html/pipeline/relative_link_filter.rb
+++ b/lib/html/pipeline/relative_link_filter.rb
@@ -18,7 +18,7 @@ module HTML
 
         base = context[:base_url]
         # Base should always end in /
-        base = base + "/" unless base[-1] == "/"
+        base += "/" unless base.end_with?("/")
         @base_url = Addressable::URI.parse(base)
       end
 
@@ -46,7 +46,8 @@ module HTML
       end
 
       def apply_filter(node, attribute)
-        if attr = node.attributes[attribute]
+        attr = node.attributes[attribute]
+        if attr
           new_url = make_relative(attr.value)
           attr.value = new_url if new_url
         end
@@ -56,7 +57,7 @@ module HTML
         return unless url
 
         # Explicit protocol, e.g. https://example.com/
-        return if url.match(%r{^[a-z][a-z0-9\+\.\-]+:}i)
+        return if url =~ %r!^[a-z][a-z0-9\+\.\-]+:!i
         # Protocol relative, e.g. //example.com/
         return if url.start_with?("//")
         # Hash, e.g #foobar
@@ -75,11 +76,11 @@ module HTML
       def corrected_link(link)
         url = @base_url
 
-        if link.start_with?("/")
-          url = url.join(link.sub(%r{^/}, ''))
-        else
-          url = url.join(context[:current_url]).join(link)
-        end
+        url = if link.start_with?("/")
+                url.join(link.sub("/", ""))
+              else
+                url.join(context[:current_url]).join(link)
+              end
 
         url.to_s
       end

--- a/lib/html/pipeline/relative_link_filter.rb
+++ b/lib/html/pipeline/relative_link_filter.rb
@@ -52,9 +52,11 @@ module HTML
         # Explicit protocol, e.g. https://example.com/
         return if url.match(%r{^[a-z][a-z0-9\+\.\-]+:}i)
         # Protocol relative, e.g. //example.com/
-        return if url.match(%r{^//})
+        return if url.start_with?("//")
         # Hash, e.g #foobar
-        return if url.match(/^#/)
+        return if url.start_with?("#")
+        # Already includes base url
+        return if url.start_with?(@base_url.to_s) && @base_url.to_s != "/"
 
         corrected_link(url)
       end
@@ -67,7 +69,7 @@ module HTML
       def corrected_link(link)
         url = @base_url
 
-        if link[0] == "/"
+        if link.start_with?("/")
           url = url.join(link.sub(%r{^/}, ''))
         else
           url = url.join(context[:current_url]).join(link)

--- a/lib/html/pipeline/relative_link_filter.rb
+++ b/lib/html/pipeline/relative_link_filter.rb
@@ -62,8 +62,6 @@ module HTML
         return if url.start_with?("//")
         # Hash, e.g #foobar
         return if url.start_with?("#")
-        # Already includes base url
-        return if url.start_with?(@base_url.to_s) && @base_url.to_s != "/"
 
         corrected_link(url)
       end
@@ -76,9 +74,14 @@ module HTML
       def corrected_link(link)
         url = @base_url
 
-        url = if link.start_with?("/")
+        url = if link.start_with?(url.path)
+                # Link already includes our base url
+                url.join(link)
+              elsif link.start_with?("/")
+                # Make link relative to base
                 url.join(link.sub("/", ""))
               else
+                # Make link relative to base and current page
                 url.join(context[:current_url]).join(link)
               end
 

--- a/lib/html/pipeline/relative_link_filter.rb
+++ b/lib/html/pipeline/relative_link_filter.rb
@@ -1,0 +1,80 @@
+require "html/pipeline"
+require "addressable"
+
+module HTML
+  class Pipeline
+    # Relative link filter modifies relative links based on viewing location,
+    # making it so these links lead to the correct desination no matter where
+    # they are viewed from.
+    #
+    # Requires values passed in the context:
+    #
+    # base_url    - path that all links should be relative to
+    # current_url - path where this content is being shown
+    #                (e.g. "", "index.html", or "nested/dir")
+    class RelativeLinkFilter < Filter
+      def initialize(doc, context = nil, result = nil)
+        super
+
+        base = context[:base_url]
+        # Base should always end in /
+        base = base + "/" unless base[-1] == "/"
+        @base_url = Addressable::URI.parse(base)
+      end
+
+      def call
+        return doc unless should_process?
+
+        doc.search("a").each do |node|
+          apply_filter node, "href"
+        end
+        doc.search("img").each do |node|
+          apply_filter node, "src"
+        end
+
+        doc
+      end
+
+      def should_process?
+        context[:base_url] && context[:current_url]
+      end
+
+      def apply_filter(node, attribute)
+        if attr = node.attributes[attribute]
+          new_url = make_relative(attr.value)
+          attr.value = new_url if new_url
+        end
+      end
+
+      def make_relative(url)
+        return unless url
+
+        # Explicit protocol, e.g. https://example.com/
+        return if url.match(%r{^[a-z][a-z0-9\+\.\-]+:}i)
+        # Protocol relative, e.g. //example.com/
+        return if url.match(%r{^//})
+        # Hash, e.g #foobar
+        return if url.match(/^#/)
+
+        corrected_link(url)
+      end
+
+      private
+
+      # Build a more absolute relative link
+      #
+      # link - original link
+      def corrected_link(link)
+        url = @base_url
+
+        if link[0] == "/"
+          url = url.join(link.sub(%r{^/}, ''))
+        else
+          url = url.join(context[:current_url]).join(link)
+        end
+
+        url.to_s
+      end
+    end
+  end
+end

--- a/lib/html/pipeline/relative_link_filter.rb
+++ b/lib/html/pipeline/relative_link_filter.rb
@@ -31,6 +31,12 @@ module HTML
         doc.search("img").each do |node|
           apply_filter node, "src"
         end
+        doc.search("script").each do |node|
+          apply_filter node, "src"
+        end
+        doc.search("link").each do |node|
+          apply_filter node, "href"
+        end
 
         doc
       end

--- a/lib/jekyll-relative-links.rb
+++ b/lib/jekyll-relative-links.rb
@@ -1,4 +1,5 @@
 require "jekyll"
+require "html/pipeline/relative_link_filter"
 require "jekyll-relative-links/generator"
 require "jekyll-relative-links/context"
 

--- a/lib/jekyll-relative-links.rb
+++ b/lib/jekyll-relative-links.rb
@@ -4,4 +4,39 @@ require "jekyll-relative-links/generator"
 require "jekyll-relative-links/context"
 
 module JekyllRelativeLinks
+  class << self
+    def relativize(doc)
+      base_url = Addressable::URI.join(
+        doc.site.config["url"].to_s,
+        ensure_leading_slash(doc.site.config["baseurl"])
+      ).normalize.to_s
+
+      doc.output = filter(base_url, doc.url).call(doc.output)[:output].to_s
+    end
+
+    def filter(base_url, current_url)
+      HTML::Pipeline.new(
+        [HTML::Pipeline::RelativeLinkFilter],
+        {:base_url => base_url, :current_url => current_url}
+      )
+    end
+
+    # Public: Defines the conditions for a document to be relativizable.
+    #
+    # doc - the Jekyll::Document or Jekyll::Page
+    #
+    # Returns true if the doc is written & is HTML.
+    def relativizable?(doc)
+      (doc.is_a?(Jekyll::Page) || doc.write?) &&
+        doc.output_ext == ".html" || (doc.permalink && doc.permalink.end_with?("/"))
+    end
+
+    def ensure_leading_slash(url)
+      url[0] == "/" ? url : "/#{url}"
+    end
+  end
+end
+
+Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
+  JekyllRelativeLinks.relativize(doc) if JekyllRelativeLinks.relativizable?(doc)
 end

--- a/lib/jekyll-relative-links.rb
+++ b/lib/jekyll-relative-links.rb
@@ -17,7 +17,7 @@ module JekyllRelativeLinks
     def filter(base_url, current_url)
       HTML::Pipeline.new(
         [HTML::Pipeline::RelativeLinkFilter],
-        {:base_url => base_url, :current_url => current_url}
+        { :base_url => base_url, :current_url => current_url }
       )
     end
 

--- a/spec/html/pipeline/relative_link_filter_spec.rb
+++ b/spec/html/pipeline/relative_link_filter_spec.rb
@@ -78,6 +78,37 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
         expect(filter_link("/absolute")).to eql("/absolute")
       end
     end
+
+    context "with a fully-qualified base" do
+      let(:context) do
+        { :current_url => "", :base_url => "http://example.com/foo" }
+      end
+
+      it "prefixes relative urls with root" do
+        expect(filter_link("relative")).to eql("http://example.com/foo/relative")
+      end
+
+      it "prefixes relative urls with root and current path" do
+        context[:current_url] = "current/page"
+        expect(filter_link("relative")).to eql("http://example.com/foo/current/relative")
+      end
+
+      it "prefixes relative urls with root and current path as a directory" do
+        context[:current_url] = "current/page/"
+        expect(filter_link("relative")).to eql(
+          "http://example.com/foo/current/page/relative"
+        )
+      end
+
+      it "makes absolute urls relative to root" do
+        context[:current_url] = "current/page"
+        expect(filter_link("/absolute")).to eql("http://example.com/foo/absolute")
+      end
+
+      it "does not duplicate root if it already exists" do
+        expect(filter_link("/foo/bar")).to eql("http://example.com/foo/bar")
+      end
+    end
   end
 
   describe "images" do

--- a/spec/html/pipeline/relative_link_filter_spec.rb
+++ b/spec/html/pipeline/relative_link_filter_spec.rb
@@ -25,9 +25,13 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
         expect(filter_link("relative")).to eql("/root/current/page/relative")
       end
 
-      it "makes absolute urls relative to root root" do
+      it "makes absolute urls relative to root" do
         context[:current_url] = "current/page"
         expect(filter_link("/absolute")).to eql("/root/absolute")
+      end
+
+      it "does not duplicate root if it already exists" do
+        expect(filter_link("/root/foo")).to eql("/root/foo")
       end
 
       it "ignores external URLs" do
@@ -69,7 +73,7 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
         expect(filter_link("relative")).to eql("/current/page/relative")
       end
 
-      it "makes absolute urls relative to root root" do
+      it "makes absolute urls relative to root" do
         context[:current_url] = "current/page"
         expect(filter_link("/absolute")).to eql("/absolute")
       end
@@ -102,7 +106,7 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
         expect(filter_img("relative.png")).to eql("/root/current/page/relative.png")
       end
 
-      it "makes absolute urls relative to root root" do
+      it "makes absolute urls relative to root" do
         context[:current_url] = "current/page"
         expect(filter_img("/absolute.png")).to eql("/root/absolute.png")
       end
@@ -142,7 +146,7 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
         expect(filter_img("relative")).to eql("/current/page/relative")
       end
 
-      it "makes absolute urls relative to root root" do
+      it "makes absolute urls relative to root" do
         context[:current_url] = "current/page"
         expect(filter_img("/absolute")).to eql("/absolute")
       end

--- a/spec/html/pipeline/relative_link_filter_spec.rb
+++ b/spec/html/pipeline/relative_link_filter_spec.rb
@@ -1,0 +1,152 @@
+RSpec.describe HTML::Pipeline::RelativeLinkFilter do
+  def filter_link(url)
+    content = %|<a href="#{url}">thing</a>|
+    result = HTML::Pipeline::RelativeLinkFilter.new(content, context, nil).call
+    result.search('a').first.attribute('href').value
+  end
+
+  describe "anchors" do
+    context 'with a root of /root' do
+      let(:context) do
+        { :current_url => "", :base_url => "/root" }
+      end
+
+      it "prefixes relative urls with root" do
+        expect(filter_link("relative")).to eql("/root/relative")
+      end
+
+      it "prefixes relative urls with root and current path" do
+        context[:current_url] = "current/page"
+        expect(filter_link("relative")).to eql("/root/current/relative")
+      end
+
+      it "prefixes relative urls with root and current path as a directory" do
+        context[:current_url] = "current/page/"
+        expect(filter_link("relative")).to eql("/root/current/page/relative")
+      end
+
+      it "makes absolute urls relative to root root" do
+        context[:current_url] = "current/page"
+        expect(filter_link("/absolute")).to eql("/root/absolute")
+      end
+
+      it "ignores external URLs" do
+        expect(filter_link("https://example.com")).to eql("https://example.com")
+      end
+
+      it "ignores hashes" do
+        expect(filter_link("#foobar")).to eql("#foobar")
+      end
+
+      it "ignores protocol relative urls" do
+        expect(filter_link("//example.com")).to eql("//example.com")
+      end
+
+      it "ignores anchors without an href" do
+        content = %|<a name="foo">thing</a>|
+        result = HTML::Pipeline::RelativeLinkFilter.new(content, context, nil).call
+        href = result.search('a').first.attribute('href')
+        expect(href).to be(nil)
+      end
+    end
+
+    context 'with a root of ""' do
+      let(:context) do
+        { :current_url => "", :base_url => "" }
+      end
+
+      it "prefixes relative urls with root" do
+        expect(filter_link("relative")).to eql("/relative")
+      end
+
+      it "prefixes relative urls with root and current path" do
+        context[:current_url] = "current/page"
+        expect(filter_link("relative")).to eql("/current/relative")
+      end
+
+      it "prefixes relative urls with root and current path as a directory" do
+        context[:current_url] = "current/page/"
+        expect(filter_link("relative")).to eql("/current/page/relative")
+      end
+
+      it "makes absolute urls relative to root root" do
+        context[:current_url] = "current/page"
+        expect(filter_link("/absolute")).to eql("/absolute")
+      end
+    end
+  end
+
+  describe "images" do
+    def filter_img(url)
+      content = %|<img src="#{url}">|
+      result = HTML::Pipeline::RelativeLinkFilter.new(content, context, nil).call
+      result.search('img').first.attribute('src').value
+    end
+
+    context 'with a root of /root' do
+      let(:context) do
+        { :current_url => "", :base_url => "/root" }
+      end
+
+      it "prefixes relative urls with root" do
+        expect(filter_img("relative.png")).to eql("/root/relative.png")
+      end
+
+      it "prefixes relative urls with root and current path" do
+        context[:current_url] = "current/page"
+        expect(filter_img("relative.png")).to eql("/root/current/relative.png")
+      end
+
+      it "prefixes relative urls with root and current path as a directory" do
+        context[:current_url] = "current/page/"
+        expect(filter_img("relative.png")).to eql("/root/current/page/relative.png")
+      end
+
+      it "makes absolute urls relative to root root" do
+        context[:current_url] = "current/page"
+        expect(filter_img("/absolute.png")).to eql("/root/absolute.png")
+      end
+
+      it "ignores external URLs" do
+        expect(filter_img("https://example.com/foo.png")).to eql("https://example.com/foo.png")
+      end
+
+      it "ignores protocol relative urls" do
+        expect(filter_img("//example.com/foo.png")).to eql("//example.com/foo.png")
+      end
+
+      it "ignores images without a src" do
+        content = %|<img alt="yep">|
+        result = HTML::Pipeline::RelativeLinkFilter.new(content, context, nil).call
+        src = result.search('img').first.attribute('src')
+        expect(src).to be(nil)
+      end
+    end
+
+    context 'with a root of ""' do
+      let(:context) do
+        { :current_url => "", :base_url => "" }
+      end
+
+      it "prefixes relative urls with root" do
+        expect(filter_img("relative")).to eql("/relative")
+      end
+
+      it "prefixes relative urls with root and current path" do
+        context[:current_url] = "current/page"
+        expect(filter_img("relative")).to eql("/current/relative")
+      end
+
+      it "prefixes relative urls with root and current path as a directory" do
+        context[:current_url] = "current/page/"
+        expect(filter_img("relative")).to eql("/current/page/relative")
+      end
+
+      it "makes absolute urls relative to root root" do
+        context[:current_url] = "current/page"
+        expect(filter_img("/absolute")).to eql("/absolute")
+      end
+    end
+  end
+
+end

--- a/spec/html/pipeline/relative_link_filter_spec.rb
+++ b/spec/html/pipeline/relative_link_filter_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe HTML::Pipeline::RelativeLinkFilter do
   def filter_link(url)
-    content = %|<a href="#{url}">thing</a>|
+    content = %(<a href="#{url}">thing</a>)
     result = HTML::Pipeline::RelativeLinkFilter.new(content, context, nil).call
-    result.search('a').first.attribute('href').value
+    result.search("a").first.attribute("href").value
   end
 
   describe "anchors" do
-    context 'with a root of /root' do
+    context "with a root of /root" do
       let(:context) do
         { :current_url => "", :base_url => "/root" }
       end
@@ -47,14 +47,14 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
       end
 
       it "ignores anchors without an href" do
-        content = %|<a name="foo">thing</a>|
+        content = %(<a name="foo">thing</a>)
         result = HTML::Pipeline::RelativeLinkFilter.new(content, context, nil).call
-        href = result.search('a').first.attribute('href')
+        href = result.search("a").first.attribute("href")
         expect(href).to be(nil)
       end
     end
 
-    context 'with a root of ""' do
+    context "with an empty root" do
       let(:context) do
         { :current_url => "", :base_url => "" }
       end
@@ -82,12 +82,12 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
 
   describe "images" do
     def filter_img(url)
-      content = %|<img src="#{url}">|
+      content = %(<img src="#{url}">)
       result = HTML::Pipeline::RelativeLinkFilter.new(content, context, nil).call
-      result.search('img').first.attribute('src').value
+      result.search("img").first.attribute("src").value
     end
 
-    context 'with a root of /root' do
+    context "with a root of /root" do
       let(:context) do
         { :current_url => "", :base_url => "/root" }
       end
@@ -112,7 +112,9 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
       end
 
       it "ignores external URLs" do
-        expect(filter_img("https://example.com/foo.png")).to eql("https://example.com/foo.png")
+        expect(filter_img("https://example.com/foo.png")).to eql(
+          "https://example.com/foo.png"
+        )
       end
 
       it "ignores protocol relative urls" do
@@ -120,9 +122,9 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
       end
 
       it "ignores images without a src" do
-        content = %|<img alt="yep">|
+        content = %(<img alt="yep">)
         result = HTML::Pipeline::RelativeLinkFilter.new(content, context, nil).call
-        src = result.search('img').first.attribute('src')
+        src = result.search("img").first.attribute("src")
         expect(src).to be(nil)
       end
     end
@@ -152,5 +154,4 @@ RSpec.describe HTML::Pipeline::RelativeLinkFilter do
       end
     end
   end
-
 end


### PR DESCRIPTION
I'm struggling to come up with a way to make content for [opensource.guide](https://github.com/github/open-source-guide) render on both GitHub and the pages site. Current solutions require using Jekyll filters (`![][{{ "url" | relative_url }}]`), which breaks rendering on GitHub (and breaks our pedantic markdown tests since that is not valid markdown).

Here's a suggestion for an alternative approach: all "absolute" urls are assumed to be absolute to the site root, and are automatically corrected during rendering. This PR adds an HTML pipeline filter (largely borrowed from the filter used for rendering repository content on github.com) that makes urls for links and images relative to the base url.

- `<a href="/thing">link</a>` => `<a href="/baseurl/thing">link</a>`
- `<a href="thing">link</a>` => `<a href="/baseurl/currentpage/thing">link</a>`
- `<img src="/thing.png">` => `<img src="/baseurl/thing.png">`

These URLs are unaffected:

- Explicit protocol, e.g. `https://example.com/`
- Protocol relative, e.g. `//example.com/`
- Hash, e.g `#foobar`
- Already includes base url, e.g. `/baseurl/foo`

You can see progress on getting this working here: https://github.com/github/open-source-guide/pull/315.

If this works, I think would remove the need for `relative_url` and `absolute_url` filters.

@benbalter @parkr - what do you think about this approach?

cc https://github.com/github/open-source-guide/pull/307