### PR TITLE
generator: save us from 'invalid byte sequence' errors...

### DIFF
--- a/lib/jekyll-relative-links/generator.rb
+++ b/lib/jekyll-relative-links/generator.rb
@@ -44,10 +44,11 @@ module JekyllRelativeLinks
             else
               original
             end
-          rescue ArgumentError => e
-            raise e unless e.to_s.start_with?("invalid byte sequence in UTF-8")
           end
+        rescue ArgumentError => e
+          raise e unless e.to_s.start_with?("invalid byte sequence in UTF-8")
         end
+        
       end
     end
 

--- a/lib/jekyll-relative-links/generator.rb
+++ b/lib/jekyll-relative-links/generator.rb
@@ -28,20 +28,24 @@ module JekyllRelativeLinks
         next unless markdown_extension?(page.extname)
         url_base = File.dirname(page.path)
 
-        page.content.gsub!(LINK_REGEX) do |original|
-          link_type     = Regexp.last_match(2) ? :inline : :reference
-          link_text     = Regexp.last_match(link_type == :inline ? 2 : 5)
-          relative_path = Regexp.last_match(link_type == :inline ? 3 : 6)
-          fragment      = Regexp.last_match(link_type == :inline ? 4 : 7)
+        begin
+          page.content.gsub!(LINK_REGEX) do |original|
+            link_type     = Regexp.last_match(2) ? :inline : :reference
+            link_text     = Regexp.last_match(link_type == :inline ? 2 : 5)
+            relative_path = Regexp.last_match(link_type == :inline ? 3 : 6)
+            fragment      = Regexp.last_match(link_type == :inline ? 4 : 7)
 
-          relative_path.sub!(%r!\A/!, "")
-          url = url_for_path(path_from_root(relative_path, url_base))
+            relative_path.sub!(%r!\A/!, "")
+            url = url_for_path(path_from_root(relative_path, url_base))
 
-          if url
-            url << fragment if fragment
-            replacement_text(link_type, link_text, url)
-          else
-            original
+            if url
+              url << fragment if fragment
+              replacement_text(link_type, link_text, url)
+            else
+              original
+            end
+          rescue ArgumentError => e
+            raise e unless e.to_s.start_with?("invalid byte sequence in UTF-8")
           end
         end
       end

--- a/lib/jekyll-relative-links/generator.rb
+++ b/lib/jekyll-relative-links/generator.rb
@@ -48,7 +48,6 @@ module JekyllRelativeLinks
         rescue ArgumentError => e
           raise e unless e.to_s.start_with?("invalid byte sequence in UTF-8")
         end
-        
       end
     end
 


### PR DESCRIPTION
If you have a page that's not UTF-8, this plugin will cause a build failure.

/cc @benbalter 