### PR TITLE
Bail early for absolute URLs and fragments

### DIFF
--- a/lib/jekyll-relative-links/generator.rb
+++ b/lib/jekyll-relative-links/generator.rb
@@ -35,6 +35,8 @@ module JekyllRelativeLinks
 
       page.content.gsub!(LINK_REGEX) do |original|
         link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)
+        next original if fragment?(relative_path) || absolute_url?(relative_path)
+
         path = path_from_root(relative_path, url_base)
         url  = url_for_path(path)
 
@@ -93,6 +95,17 @@ module JekyllRelativeLinks
       else
         "[#{text}]: #{url}"
       end
+    end
+
+    def absolute_url?(string)
+      return unless string
+      Addressable::URI.parse(string).absolute?
+    rescue Addressable::URI::InvalidURIError
+      nil
+    end
+
+    def fragment?(string)
+      string && string.start_with?("#")
     end
   end
 end


### PR DESCRIPTION
If the relative path is really a fragment or an absolute URL, we can bail early to save having to iterate through every page and static file, which should speed things up on large sites.