### PR TITLE
Proposal to fix #29

### DIFF
--- a/jekyll-relative-links.gemspec
+++ b/jekyll-relative-links.gemspec
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "jekyll-relative-links/version"
 

--- a/spec/fixtures/site/subdir/page.md
+++ b/spec/fixtures/site/subdir/page.md
@@ -10,3 +10,9 @@
 [Dir traversal](../page.md)
 
 ![image](../jekyll-logo.png)
+
+[![linked image](../jekyll-logo.png)](../page.md)
+
+[![reference linked image](../jekyll-logo.png)][reference]
+
+[reference]: ../page.md

--- a/spec/jekyll-relative-links/generator_spec.rb
+++ b/spec/jekyll-relative-links/generator_spec.rb
@@ -148,6 +148,15 @@ RSpec.describe JekyllRelativeLinks::Generator do
       it "handles images" do
         expect(subdir_page.content).to include("![image](/jekyll-logo.png)")
       end
+
+      it "handles linked images" do
+        expect(subdir_page.content).to include("[![linked image](/jekyll-logo.png)](/page.html)")
+      end
+
+      it "handles reference linked images" do
+        expect(subdir_page.content).to include("[![reference linked image](/jekyll-logo.png)][reference]")
+        expect(subdir_page.content).to include("[reference]: /page.html")
+      end
     end
 
     context "disabled" do

--- a/spec/jekyll-relative-links/generator_spec.rb
+++ b/spec/jekyll-relative-links/generator_spec.rb
@@ -150,11 +150,13 @@ RSpec.describe JekyllRelativeLinks::Generator do
       end
 
       it "handles linked images" do
-        expect(subdir_page.content).to include("[![linked image](/jekyll-logo.png)](/page.html)")
+        expected = "[![linked image](/jekyll-logo.png)](/page.html)"
+        expect(subdir_page.content).to include(expected)
       end
 
       it "handles reference linked images" do
-        expect(subdir_page.content).to include("[![reference linked image](/jekyll-logo.png)][reference]")
+        expected = "[![reference linked image](/jekyll-logo.png)][reference]"
+        expect(subdir_page.content).to include(expected)
         expect(subdir_page.content).to include("[reference]: /page.html")
       end
     end


### PR DESCRIPTION
This is my proposal on how to fix #29.

It "dumbed down" the regex to only look for `](/url)` and `]: /url` patterns, instead of the full link syntax to not get caught up in the nested `[![alt](/url/)](/url/)` structure which is tricky to handle with regexes. This assumes there aren't any occurrences of `](...)` and `]: ...`  out there, that aren't also links. Would like some feedback on this.