### PR TITLE
fix reference link regex

### DIFF
--- a/jekyll-relative-links.gemspec
+++ b/jekyll-relative-links.gemspec
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "jekyll-relative-links/version"
 

--- a/lib/jekyll-relative-links/generator.rb
+++ b/lib/jekyll-relative-links/generator.rb
@@ -8,7 +8,7 @@ module JekyllRelativeLinks
     LINK_TEXT_REGEX = %r!([^\]]+)!
     FRAGMENT_REGEX = %r!(#.+?)?!
     INLINE_LINK_REGEX = %r!\[#{LINK_TEXT_REGEX}\]\(([^\)]+?)#{FRAGMENT_REGEX}\)!
-    REFERENCE_LINK_REGEX = %r!^\s*\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}$!
+    REFERENCE_LINK_REGEX = %r!^\s*?\[#{LINK_TEXT_REGEX}\]: (.+?)#{FRAGMENT_REGEX}\s*?$!
     LINK_REGEX = %r!(#{INLINE_LINK_REGEX}|#{REFERENCE_LINK_REGEX})!
     CONVERTER_CLASS = Jekyll::Converters::Markdown
     CONFIG_KEY = "relative_links".freeze
@@ -100,7 +100,7 @@ module JekyllRelativeLinks
       if type == :inline
         "[#{text}](#{url})"
       else
-        "[#{text}]: #{url}"
+        "\n[#{text}]: #{url}"
       end
     end
 

--- a/spec/fixtures/site/page.md
+++ b/spec/fixtures/site/page.md
@@ -37,6 +37,8 @@
 
 [Another item](_items/some-subdir/another-item.md)
 
+Content end
+
 [reference]: another-page.md
 
 [reference-with-fragment]: another-page.md#foo
@@ -44,3 +46,5 @@
 [reference-brackets]: another-page.md#(bar)
 
   [indented-reference]: another-page.md
+
+[reference-with-whitespace]: another-page.md  

--- a/spec/jekyll-relative-links/generator_spec.rb
+++ b/spec/jekyll-relative-links/generator_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe JekyllRelativeLinks::Generator do
       it "handles indented reference links" do
         expect(page.content).to include("[indented-reference]: /another-page.html")
       end
+
+      it "handles reference links with trailing whitespace" do
+        expected = "[reference-with-whitespace]: /another-page.html"
+        expect(page.content).to include(expected)
+      end
+
+      it "leaves newlines intact" do
+        expected = "\n\nContent end\n\n[reference]: /another-page.html\n\n"
+        expect(page.content).to include(expected)
+      end
     end
 
     context "with a baseurl" do


### PR DESCRIPTION
Short version: fixed a bug I introduced that breaks sites with reference links

Long version: Regexes work differently in JavaScript (which I know) and Ruby.
In JS, `\s` matches all whitepace, but not newlines. However, in ruby (and I think most languages) newlines are included. That, in combination with not using the non-greedy `*?` quantifier caused all newlines in front of a reference link to be replaced, resulting in invalid reference links, e.g. [test].
[test]: http://github.com