### PR TITLE
Guard against encoding errors

### DIFF
--- a/jekyll-relative-links.gemspec
+++ b/jekyll-relative-links.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
 
   s.add_dependency "jekyll", "~> 3.3"
-  s.add_development_dependency "rubocop", "~> 0.43"
   s.add_development_dependency "rspec", "~> 3.5"
+  s.add_development_dependency "rubocop", "~> 0.43"
 end

--- a/lib/jekyll-relative-links/generator.rb
+++ b/lib/jekyll-relative-links/generator.rb
@@ -42,6 +42,7 @@ module JekyllRelativeLinks
 
     def replace_relative_links!(document)
       url_base = File.dirname(document.relative_path)
+      return document if document.content.nil?
 
       document.content.gsub!(LINK_REGEX) do |original|
         link_type, link_text, relative_path, fragment = link_parts(Regexp.last_match)

--- a/spec/jekyll-relative-links/generator_spec.rb
+++ b/spec/jekyll-relative-links/generator_spec.rb
@@ -246,4 +246,12 @@ RSpec.describe JekyllRelativeLinks::Generator do
       end
     end
   end
+
+  context "a page without content" do
+    before { page_by_path(site, "page.md").content = nil }
+
+    it "doesn't error out" do
+      expect { subject.generate(site) }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
If Jekyll fails to read a file in due to an encoding error, `Document#content` will be `nil`. This means that calling `document.content.gsub!...` will raise a `NoMethod` error.

Instead of causing the build to fail, we should bail early from processing the document without content (since, by definition, it contains no relative links).

/cc @parkr 