### PR TITLE
Add info about permalink: pretty

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ permalink: /bar/
 
 Then `[foo](bar.md)` will render as `[foo](/bar/)`.
 
+The default Jekyll's configuration `permalink: pretty` in the `_config.yaml`
+file removes the `.html` extensions from the generated links.
+
 ## Why
 
 Because Markdown files rendered by GitHub Pages should behave similar to Markdown files rendered on GitHub.com


### PR DESCRIPTION
Hello, this patch adds a quick info in the `README.md` about the neat default option `permalink: pretty` as noted in the docs:
https://jekyllrb.com/docs/permalinks/

Works with this plugin and GitHub pages as well. So in case the permalinks are all of the same pattern of `folder/subfolder/file.md`, there is no need to define these separately in front yaml of the Markdown files.

Thanks for considering checking this out or merging it.