### PR TITLE
Handles links with titles: [e.g.](url.md "title")

### DIFF
--- a/spec/fixtures/site/page.md
+++ b/spec/fixtures/site/page.md
@@ -41,6 +41,10 @@
 
 [\[A link with escaped square brackets\]](/another-page.md)
 
+[A link with a title](another-page.md "This is a link with a \"title\"")
+
+[Quotes in url & title](/another-page.md#'apostrophe' 'Quotes in url & title')
+
 Content end
 
 [reference]: another-page.md
@@ -52,3 +56,5 @@ Content end
   [indented-reference]: another-page.md
 
 [reference-with-whitespace]: another-page.md  
+
+[reference-with-title]: another-page.md "This is a reference with a title"

--- a/spec/jekyll-relative-links/generator_spec.rb
+++ b/spec/jekyll-relative-links/generator_spec.rb
@@ -95,6 +95,17 @@ RSpec.describe JekyllRelativeLinks::Generator do
       expect(page.content).to include(expected)
     end
 
+    it "handles links with a title" do
+      expected = "[A link with a title](/another-page.html \"This is a link with a \\\"title\\\"\")"
+      expect(page.content).to include(expected)
+    end
+
+    it "handles links with quotes in url fragment and title" do
+      # single_quotes are valid in urls
+      expected = "[Quotes in url & title](/another-page.html#'apostrophe' 'Quotes in url & title')"
+      expect(page.content).to include(expected)
+    end
+
     context "reference links" do
       it "handles reference links" do
         expect(page.content).to include("[reference]: /another-page.html")
@@ -111,6 +122,11 @@ RSpec.describe JekyllRelativeLinks::Generator do
 
       it "leaves newlines intact" do
         expected = "\n\nContent end\n\n[reference]: /another-page.html\n\n"
+        expect(page.content).to include(expected)
+      end
+
+      it "handles reference links with titles" do
+        expected = "[reference-with-title]: /another-page.html \"This is a reference with a title\""
         expect(page.content).to include(expected)
       end
     end


### PR DESCRIPTION
In markdown, links can have a title, e.g. the following markdown:

```md
[Click me](example.com "Link to site")
```

will turn into the following HTML:

```html
<a href="example.com" title="Link to site">Click me</a>
```

This commit adds and tests handling both inline and reference md links
with titles, with both 'single-quotes' and "double-quotes", as in
kramdown, Github-flavoured markdown, or commonmark.

-----
[View rendered spec/fixtures/site/page.md](https://github.com/aloisklink/jekyll-relative-links/blob/handle-link-titles/spec/fixtures/site/page.md)