### PR TITLE
Urls starting with / handled as absolute urls from the root

### DIFF
--- a/lib/jekyll-relative-links/generator.rb
+++ b/lib/jekyll-relative-links/generator.rb
@@ -71,12 +71,12 @@ module JekyllRelativeLinks
 
     def link_parts(matches)
       last_inline = 5
-      link_type     = matches[2] ? :inline : :reference
-      link_text     = matches[link_type == :inline ? 2 : last_inline + 1]
+      link_type = matches[2] ? :inline : :reference
+      link_text = matches[link_type == :inline ? 2 : last_inline + 1]
       relative_path = matches[link_type == :inline ? 3 : last_inline + 2]
-      fragment      = matches[link_type == :inline ? 4 : last_inline + 3]
-      title         = matches[link_type == :inline ? 5 : last_inline + 4]
-      is_absolute   = relative_path.start_with? "/"
+      fragment = matches[link_type == :inline ? 4 : last_inline + 3]
+      title = matches[link_type == :inline ? 5 : last_inline + 4]
+      is_absolute = relative_path.start_with? "/"
       Link.new(link_type, link_text, relative_path, fragment, title, is_absolute)
     end
 

--- a/lib/jekyll-relative-links/generator.rb
+++ b/lib/jekyll-relative-links/generator.rb
@@ -53,7 +53,7 @@ module JekyllRelativeLinks
         link = link_parts(Regexp.last_match)
         next original unless replaceable_link?(link.path)
 
-        path = path_from_root(link.path, url_base, link.is_absolute)
+        path = path_from_root(link.path, url_base)
         url  = url_for_path(path)
         next original unless url
 
@@ -67,7 +67,7 @@ module JekyllRelativeLinks
     private
 
     # Stores info on a Markdown Link (avoid rubocop's Metrics/ParameterLists warning)
-    Link = Struct.new(:link_type, :text, :path, :fragment, :title, :is_absolute)
+    Link = Struct.new(:link_type, :text, :path, :fragment, :title)
 
     def link_parts(matches)
       last_inline = 5
@@ -76,8 +76,7 @@ module JekyllRelativeLinks
       relative_path = matches[link_type == :inline ? 3 : last_inline + 2]
       fragment = matches[link_type == :inline ? 4 : last_inline + 3]
       title = matches[link_type == :inline ? 5 : last_inline + 4]
-      is_absolute = relative_path.start_with? "/"
-      Link.new(link_type, link_text, relative_path, fragment, title, is_absolute)
+      Link.new(link_type, link_text, relative_path, fragment, title)
     end
 
     def context
@@ -101,7 +100,9 @@ module JekyllRelativeLinks
       @potential_targets ||= site.pages + site.static_files + site.docs_to_write
     end
 
-    def path_from_root(relative_path, url_base, is_absolute)
+    def path_from_root(relative_path, url_base)
+      is_absolute = relative_path.start_with? "/"
+
       relative_path.sub!(%r!\A/!, "")
       base = is_absolute ? "" : url_base
       absolute_path = File.expand_path(relative_path, base)

--- a/spec/fixtures/site/page.md
+++ b/spec/fixtures/site/page.md
@@ -9,6 +9,8 @@
 
 [Page with leading slash](/another-page.md)
 
+[Page with leading slash multi level](/subdir/page.md)
+
 [Reference link][reference]
 
 [Reference with fragment][reference-with-fragment]

--- a/spec/fixtures/site/subdir/page.md
+++ b/spec/fixtures/site/subdir/page.md
@@ -9,4 +9,6 @@
 
 [Dir traversal](../page.md)
 
+[leading slash starts from the root](/another-page.md)
+
 ![image](../jekyll-logo.png)

--- a/spec/jekyll-relative-links/generator_spec.rb
+++ b/spec/jekyll-relative-links/generator_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe JekyllRelativeLinks::Generator do
       expect(page.content).to include("[Page with leading slash](/another-page.html)")
     end
 
+    it "converts relative links with leading slashes in sub dir" do
+      expect(page.content).to include("[Page with leading slash multi level](/subdir/page.html)")
+    end
+
     it "converts pages in sub-directories" do
       expect(page.content).to include("[Subdir Page](/subdir/page.html)")
     end
@@ -75,6 +79,11 @@ RSpec.describe JekyllRelativeLinks::Generator do
 
     it "handles directory traversal" do
       expect(subdir_page.content).to include("[Dir traversal](/page.html)")
+    end
+
+    it "handles paths from the root" do
+      expected = "[leading slash starts from the root](/another-page.html)"
+      expect(subdir_page.content).to include(expected)
     end
 
     it "Handles HTML pages" do


### PR DESCRIPTION
This pull requests makes absolute urls behave the same way as on github. A url that starts with a / should be interpreted as an absolute url, starting from the root.

Example:
if we have the file foo/bar.md, containing the link `[my absolute link](/foo/bar.md)`, the generated html should point to /foo/bar/



-----
[View rendered spec/fixtures/site/page.md](https://github.com/krichardsson/jekyll-relative-links/blob/fix-absolute-urls/spec/fixtures/site/page.md)
[View rendered spec/fixtures/site/subdir/page.md](https://github.com/krichardsson/jekyll-relative-links/blob/fix-absolute-urls/spec/fixtures/site/subdir/page.md)