### PR TITLE
Use O(1) hash lookup in url_for_path

### DIFF
--- a/lib/jekyll-relative-links/generator.rb
+++ b/lib/jekyll-relative-links/generator.rb
@@ -101,12 +101,25 @@ module JekyllRelativeLinks
     end
 
     def url_for_path(path)
-      target = potential_targets.find { |p| p.relative_path.sub(%r!\A/!, "") == path }
+      target = potential_targets_by_path[path]
       relative_url(target.url) if target&.url
     end
 
     def potential_targets
       @potential_targets ||= site.pages + site.static_files + site.docs_to_write
+    end
+
+    # Index `potential_targets` by the same key the previous linear `find`
+    # compared against, so each `url_for_path` lookup is O(1) instead of
+    # O(N). On a site with M markdown link matches and N potential
+    # targets, total link-resolution cost goes from O(M*N) to O(M+N).
+    # First-wins semantics are preserved against the (unlikely) case of
+    # two targets sharing the same `relative_path`.
+    def potential_targets_by_path
+      @potential_targets_by_path ||= potential_targets.each_with_object({}) do |p, h|
+        key = p.relative_path.sub(%r!\A/!, "")
+        h[key] = p unless h.key?(key)
+      end
     end
 
     def path_from_root(relative_path, url_base)


### PR DESCRIPTION
## Summary

`url_for_path` does a linear `.find` through `potential_targets` (`site.pages + site.static_files + site.docs_to_write`) for every markdown link match in every document. With M link matches and N targets, total link-resolution cost is O(M*N).

Indexing `potential_targets` by `relative_path` once and looking up by hash key drops each call to O(1).

## Measured impact

On a Jekyll site with ~6,800 markdown link matches across ~1,050 potential targets, the GENERATE phase contribution from this plugin drops from ~4,000ms to ~970ms -- about a 3-second saving on a site whose GENERATE phase otherwise takes ~600ms.

## Behaviour preserved

- Existing tests still pass (76/77 on Windows; the one failure, ``converts relative links with symbols``, can't be checked out on Windows because its fixture filename contains ``?``, and is unrelated to this change).
- Hash construction iterates `potential_targets` in order with `unless h.key?(key)`, preserving the first-wins semantics of the original `.find` against the unlikely case of two targets sharing the same `relative_path`.
- Memoisation cadence is identical to `potential_targets` itself (same instance-variable lifecycle).