### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## 0.8.0
+
+### Features
+
+- Add a `rellinks` Liquid filter that rewrites relative links in already-
+  markdownified content — usable as `{{ content | markdownify | rellinks }}`,
+  so links inside included fragments get converted (#98)
+
+### Bug fixes
+
+- Convert relative links in Jekyll includes that were previously skipped (#104)
+- Handle hex-encoded (`%20`) spaces in relative link paths (#106)
+- Correctly handle images nested inside Markdown links (#107)
+- Fix an error when a page's YAML front matter has an `excerpt:` field (#97)
+
+### Performance
+
+- Use an O(1) hash lookup in `url_for_path`, speeding up link resolution on
+  large sites (#110)
+
+### Documentation
+
+- Document that line-wrapped links are not processed, per the CommonMark spec
+  (#105)
+
+### Infrastructure
+
+- Modernize CI — Ruby 3.3 & 4.0 against Jekyll 3.x & 4.x — and bump
+  rubocop-rspec to `~> 3.0` (#115)
+- Enable Dependabot for GitHub Actions; bump `actions/checkout`,
+  `github/codeql-action`, and `rubocop-factory_bot` (#111, #112, #113, #114)

--- a/lib/jekyll-relative-links/version.rb
+++ b/lib/jekyll-relative-links/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllRelativeLinks
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
Prepares **v0.8.0** (minor — new feature). Adds a `CHANGELOG.md` (none existed). Publish is a manual `gem push` after merge.

**Bump:** 0.7.0 → 0.8.0 (minor: introduces the `rellinks` filter)

### Changelog
**Features**
- Add a `rellinks` Liquid filter for relative links in markdownified content (`{{ content | markdownify | rellinks }}`) (#98)

**Bug fixes**
- Convert relative links in Jekyll includes that were previously skipped (#104)
- Handle hex-encoded (`%20`) spaces in relative link paths (#106)
- Correctly handle images nested inside Markdown links (#107)
- Fix an error when a page's front matter has an `excerpt:` field (#97)

**Performance**
- O(1) hash lookup in `url_for_path` for large sites (#110)

**Documentation**
- Document that line-wrapped links aren't processed, per CommonMark (#105)

**Infrastructure**
- Modernize CI + rubocop-rspec `~> 3.0` (#115); Dependabot for Actions + bumps (#111–#114)

🤖 Generated with [Claude Code](https://claude.com/claude-code)